### PR TITLE
lein-ancient 0.6.1 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -51,6 +51,6 @@
                                                ["bikeshed"]
                                                ["eastwood"]]}
                    :plugins [[jonase/eastwood "0.1.4"]
-                             [lein-ancient "0.5.5"]
+                             [lein-ancient "0.6.1"]
                              [lein-bikeshed "0.1.8"]
                              [lein-kibit "0.0.8"]]}})


### PR DESCRIPTION
lein-ancient 0.6.1 has been released. Previous version was 0.6.0.

This pull request is created on behalf of @lvh