### PR TITLE
prismatic/schema 0.3.7 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,7 @@
                  [http-kit "2.1.19"]
 
                  ;; Schemata
-                 [prismatic/schema "0.3.6"]
+                 [prismatic/schema "0.3.7"]
                  [schema-contrib "0.1.5"
                   :exclusions [instaparse]]
                  [cddr/integrity "0.2.0-20140823.193326-1"


### PR DESCRIPTION
prismatic/schema 0.3.7 has been released. Previous version was 0.3.6.

This pull request is created on behalf of @lvh