### PR TITLE
lein-ancient 0.6.2 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -52,6 +52,6 @@
                                         ["bikeshed"]
                                         ["eastwood"]]}
                    :plugins [[jonase/eastwood "0.1.4"]
-                             [lein-ancient "0.6.1"]
+                             [lein-ancient "0.6.2"]
                              [lein-bikeshed "0.1.8"]
                              [lein-kibit "0.0.8"]]}})


### PR DESCRIPTION
lein-ancient 0.6.2 has been released. Previous version was 0.6.1.

This pull request is created on behalf of @lvh