### PR TITLE
com.taoensso/timbre 3.4.0 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,7 @@
                  [caesium "0.3.0"]
 
                  ;; Logging
-                 [com.taoensso/timbre "3.3.1" :exclusions [org.clojure/clojure]]
+                 [com.taoensso/timbre "3.4.0" :exclusions [org.clojure/clojure]]
 
                  ;; REST API
                  ;; http-kit already required as part of handlers


### PR DESCRIPTION
com.taoensso/timbre 3.4.0 has been released. Previous version was 3.3.1-1cd4b70.

This pull request is created on behalf of @lvh