### PR TITLE
aleph 0.4.0-beta3 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,7 @@
 
                  ;; Handlers
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
-                 [aleph "0.4.0-beta2"]
+                 [aleph "0.4.0-beta3"]
 
                  ;; Schemata
                  [prismatic/schema "0.3.7"]


### PR DESCRIPTION
aleph 0.4.0-beta3 has been released. Previous version was 0.4.0-beta2.

This pull request is created on behalf of @lvh