### PR TITLE
com.taoensso/nippy 2.8.0 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                  [com.novemberain/welle "3.0.0"]
 
                  ;; Serialization
-                 [com.taoensso/nippy "2.7.1"
+                 [com.taoensso/nippy "2.8.0"
                   :exclusions [org.clojure/clojure com.taoensso/encore]]
 
                  ;; Handlers


### PR DESCRIPTION
com.taoensso/nippy 2.8.0 has been released. Previous version was 2.7.1.

This pull request is created on behalf of @lvh