### PR TITLE
org.clojure/core.typed 0.2.82 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
                   :exclusions [instaparse]]
                  [cddr/integrity "0.2.0-20140823.193326-1"
                   :exclusions [org.clojure/clojure]]
-                 [org.clojure/core.typed "0.2.78"]
+                 [org.clojure/core.typed "0.2.82"]
 
                  ;; Crypto
                  [caesium "0.3.0"]


### PR DESCRIPTION
org.clojure/core.typed 0.2.82 has been released. Previous version was 0.2.81.

This pull request is created on behalf of @lvh