### PR TITLE
org.clojure/core.typed 0.2.83 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
                   :exclusions [instaparse]]
                  [cddr/integrity "0.2.0-20140823.193326-1"
                   :exclusions [org.clojure/clojure]]
-                 [org.clojure/core.typed "0.2.82"]
+                 [org.clojure/core.typed "0.2.83"]
 
                  ;; Crypto
                  [caesium "0.3.0"]


### PR DESCRIPTION
org.clojure/core.typed 0.2.83 has been released. Previous version was 0.2.82.

This pull request is created on behalf of @lvh