### PR TITLE
lein-ancient 0.6.4 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -51,7 +51,7 @@
                                         ["bikeshed"]
                                         ["eastwood"]]}
                    :plugins [[jonase/eastwood "0.1.4"]
-                             [lein-ancient "0.6.2"
+                             [lein-ancient "0.6.4"
                               :exclusions [rewrite-clj]]
                              [lein-bikeshed "0.1.8"]
                              [lein-cljfmt "0.1.10"]


### PR DESCRIPTION
lein-ancient 0.6.4 has been released. Previous version was 0.6.3.

This pull request is created on behalf of @lvh