### PR TITLE
ring-middleware-format 0.5.0 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -34,7 +34,7 @@
                  ;; REST API
                  [compojure "1.3.2"]
                  [ring/ring-defaults "0.1.4"]
-                 [ring-middleware-format "0.4.0"]]
+                 [ring-middleware-format "0.5.0"]]
   :test-selectors {:default (complement (some-fn :riak))
                    :riak :riak}
   :main ^:skip-aot icecap.core


### PR DESCRIPTION
ring-middleware-format 0.5.0 has been released. Previous version was 0.4.0.

This pull request is created on behalf of @lvh