### PR TITLE
compojure 1.3.3 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -32,7 +32,7 @@
                   :exclusions [org.clojure/clojure]]
 
                  ;; REST API
-                 [compojure "1.3.2"]
+                 [compojure "1.3.3"]
                  [ring/ring-defaults "0.1.4"]
                  [ring-middleware-format "0.5.0"]]
   :test-selectors {:default (complement (some-fn :riak))


### PR DESCRIPTION
compojure 1.3.3 has been released. Previous version was 1.3.2.

This pull request is created on behalf of @lvh