### PR TITLE
aleph 0.4.0 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
 
                  ;; Handlers
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
-                 [aleph "0.4.0-beta3"]
+                 [aleph "0.4.0"]
 
                  ;; Schemata
                  [prismatic/schema "0.4.0"]


### PR DESCRIPTION
aleph 0.4.0 has been released. Previous version was 0.4.0-beta3.

This pull request is created on behalf of @lvh