### PR TITLE
lein-ancient 0.6.7 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -54,7 +54,7 @@
                                         ["bikeshed"]
                                         ["eastwood"]]}
                    :plugins [[jonase/eastwood "0.1.4"]
-                             [lein-ancient "0.6.6"
+                             [lein-ancient "0.6.7"
                               :exclusions [rewrite-clj]]
                              [lein-bikeshed "0.1.8"]
                              [lein-cljfmt "0.1.10"]


### PR DESCRIPTION
lein-ancient 0.6.7 has been released. Previous version was 0.6.6.

This pull request is created on behalf of @lvh