### PR TITLE
org.clojure/test.check 0.8.0-ALPHA released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -43,7 +43,7 @@
   :main ^:skip-aot icecap.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}
-             :dev {:dependencies [[org.clojure/test.check "0.7.0"]]
+             :dev {:dependencies [[org.clojure/test.check "0.8.0-ALPHA"]]
                    :aliases ^:replace {"lint"
                                        ["do"
                                         ["clean"]


### PR DESCRIPTION
org.clojure/test.check 0.8.0-ALPHA has been released. Previous version was 0.7.0.

This pull request is created on behalf of @lvh