### PR TITLE
lein-kibit 0.1.2 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -58,4 +58,4 @@
                               :exclusions [rewrite-clj]]
                              [lein-bikeshed "0.1.8"]
                              [lein-cljfmt "0.1.10"]
-                             [lein-kibit "0.0.8"]]}})
+                             [lein-kibit "0.1.2"]]}})


### PR DESCRIPTION
lein-kibit 0.1.2 has been released. Previous version was 0.1.0.

This pull request is created on behalf of @lvh