### PR TITLE
ring/ring-defaults 0.1.5 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -33,7 +33,7 @@
 
                  ;; REST API
                  [compojure "1.3.3"]
-                 [ring/ring-defaults "0.1.4"]
+                 [ring/ring-defaults "0.1.5"]
                  [ring-middleware-format "0.5.0"]
 
                  ;; REST API testing


### PR DESCRIPTION
ring/ring-defaults 0.1.5 has been released. Previous version was 0.1.4.

This pull request is created on behalf of @lvh