### PR TITLE
prismatic/schema 0.4.3 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,7 @@
                  [aleph "0.4.0"]
 
                  ;; Schemata
-                 [prismatic/schema "0.4.2"]
+                 [prismatic/schema "0.4.3"]
                  [schema-contrib "0.1.5"
                   :exclusions [instaparse]]
                  [cddr/integrity "0.3.0-SNAPSHOT"


### PR DESCRIPTION
prismatic/schema 0.4.3 has been released. Previous version was 0.4.2.

This pull request is created on behalf of @lvh