### PR TITLE
com.taoensso/timbre 4.0.0-beta1 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [caesium "0.3.0"]
 
                  ;; Logging
-                 [com.taoensso/timbre "3.4.0"
+                 [com.taoensso/timbre "4.0.0-beta1"
                   :exclusions [org.clojure/clojure]]
 
                  ;; REST API


### PR DESCRIPTION
com.taoensso/timbre 4.0.0-beta1 has been released. Previous version was 3.4.0.

This pull request is created on behalf of @lvh