### PR TITLE
aleph 0.4.1-alpha1 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
 
                  ;; Handlers
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
-                 [aleph "0.4.0"]
+                 [aleph "0.4.1-alpha1"]
 
                  ;; Schemata
                  [prismatic/schema "0.4.3"]


### PR DESCRIPTION
aleph 0.4.1-alpha1 has been released. Previous version was 0.4.0.

This pull request is created on behalf of @lvh