### PR TITLE
lein-cljfmt 0.2.1 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -57,5 +57,5 @@
                              [lein-ancient "0.6.7"
                               :exclusions [rewrite-clj]]
                              [lein-bikeshed "0.1.8"]
-                             [lein-cljfmt "0.2.0"]
+                             [lein-cljfmt "0.2.1"]
                              [lein-kibit "0.1.0"]]}})


### PR DESCRIPTION
lein-cljfmt 0.2.1 has been released. Previous version was 0.2.0.

This pull request is created on behalf of @lvh