### PR TITLE
com.taoensso/timbre 4.1.0 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [caesium "0.3.0"]
 
                  ;; Logging
-                 [com.taoensso/timbre "4.1.0-alpha2"
+                 [com.taoensso/timbre "4.1.0"
                   :exclusions [org.clojure/clojure]]
 
                  ;; REST API


### PR DESCRIPTION
com.taoensso/timbre 4.1.0 has been released. Previous version was 4.1.0-alpha2.

This pull request is created on behalf of @lvh