### PR TITLE
org.clojure/test.check 0.8.1 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -43,7 +43,7 @@
   :main ^:skip-aot icecap.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}
-             :dev {:dependencies [[org.clojure/test.check "0.8.0-RC3"]]
+             :dev {:dependencies [[org.clojure/test.check "0.8.1"]]
                    :aliases ^:replace {"lint"
                                        ["do"
                                         ["clean"]


### PR DESCRIPTION
org.clojure/test.check 0.8.1 has been released. Previous version was 0.8.0.

This pull request is created on behalf of @lvh