### PR TITLE
prismatic/schema 1.0.1 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,7 @@
                  [aleph "0.4.1-alpha2"]
 
                  ;; Schemata
-                 [prismatic/schema "1.0.0"]
+                 [prismatic/schema "1.0.1"]
                  [schema-contrib "0.1.5"
                   :exclusions [instaparse]]
                  [org.clojure/core.typed "0.3.11"]


### PR DESCRIPTION
prismatic/schema 1.0.1 has been released. Previous version was 1.0.0.

This pull request is created on behalf of @lvh