### PR TITLE
org.clojure/test.check 0.8.2 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -41,7 +41,7 @@
   :main ^:skip-aot icecap.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}
-             :dev {:dependencies [[org.clojure/test.check "0.8.0"]]
+             :dev {:dependencies [[org.clojure/test.check "0.8.2"]]
                    :aliases ^:replace {"lint"
                                        ["do"
                                         ["clean"]


### PR DESCRIPTION
org.clojure/test.check 0.8.2 has been released. Previous version was 0.8.1.

This pull request is created on behalf of @lvh