### PR TITLE
com.taoensso/timbre 4.1.2 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,7 @@
                  [caesium "0.3.0"]
 
                  ;; Logging
-                 [com.taoensso/timbre "4.1.1"
+                 [com.taoensso/timbre "4.1.2"
                   :exclusions [org.clojure/clojure]]
 
                  ;; REST API


### PR DESCRIPTION
com.taoensso/timbre 4.1.2 has been released. Previous version was 4.1.1.

This pull request is created on behalf of @lvh