### PR TITLE
com.taoensso/nippy 2.11.0-private1 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                  [com.novemberain/welle "3.0.0"]
 
                  ;; Serialization
-                 [com.taoensso/nippy "2.10.0-RC2"
+                 [com.taoensso/nippy "2.11.0-private1"
                   :exclusions [org.clojure/clojure com.taoensso/encore]]
 
                  ;; Handlers


### PR DESCRIPTION
com.taoensso/nippy 2.11.0-private1 has been released. Previous version was 2.10.0-RC3.

This pull request is created on behalf of @lvh