### PR TITLE
com.taoensso/timbre 4.1.4 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,7 @@
                  [caesium "0.3.0"]
 
                  ;; Logging
-                 [com.taoensso/timbre "4.1.2"
+                 [com.taoensso/timbre "4.1.4"
                   :exclusions [org.clojure/clojure]]
 
                  ;; REST API


### PR DESCRIPTION
com.taoensso/timbre 4.1.4 has been released. Previous version was 4.1.2.

This pull request is created on behalf of @lvh