### PR TITLE
aleph 0.4.1-beta1 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
 
                  ;; Handlers
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
-                 [aleph "0.4.1-alpha2"]
+                 [aleph "0.4.1-beta1"]
 
                  ;; Schemata
                  [prismatic/schema "1.0.1"]


### PR DESCRIPTION
aleph 0.4.1-beta1 has been released. Previous version was 0.4.1-alpha3.

This pull request is created on behalf of @lvh