### PR TITLE
org.clojure/core.async 0.2.371 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
                   :exclusions [org.clojure/clojure com.taoensso/encore]]
 
                  ;; Handlers
-                 [org.clojure/core.async "0.1.346.0-17112a-alpha"]
+                 [org.clojure/core.async "0.2.371"]
                  [aleph "0.4.1-beta1"]
 
                  ;; Schemata


### PR DESCRIPTION
org.clojure/core.async 0.2.371 has been released. Previous version was 0.1.346.0-17112a-alpha.

This pull request is created on behalf of @lvh