### PR TITLE
prismatic/schema 1.0.3 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,7 @@
                  [aleph "0.4.1-beta1"]
 
                  ;; Schemata
-                 [prismatic/schema "1.0.2"]
+                 [prismatic/schema "1.0.3"]
                  [schema-contrib "0.1.5"
                   :exclusions [instaparse]]
                  [org.clojure/core.typed "0.3.14"]


### PR DESCRIPTION
prismatic/schema 1.0.3 has been released. Previous version was 1.0.2.

This pull request is created on behalf of @lvh