### PR TITLE
ring-middleware-format 0.7.0 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -32,7 +32,7 @@
                  ;; REST API
                  [compojure "1.4.0"]
                  [ring/ring-defaults "0.1.5"]
-                 [ring-middleware-format "0.6.0"]
+                 [ring-middleware-format "0.7.0"]
 
                  ;; REST API testing
                  [ring/ring-mock "0.3.0"]]


### PR DESCRIPTION
ring-middleware-format 0.7.0 has been released. Previous version was 0.6.0.

This pull request is created on behalf of @lvh