### PR TITLE
org.clojure/core.typed 0.3.16 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
                  [prismatic/schema "1.0.3"]
                  [schema-contrib "0.1.5"
                   :exclusions [instaparse]]
-                 [org.clojure/core.typed "0.3.15"]
+                 [org.clojure/core.typed "0.3.16"]
 
                  ;; Crypto
                  [caesium "0.3.0"]


### PR DESCRIPTION
org.clojure/core.typed 0.3.16 has been released. Previous version was 0.3.15.

This pull request is created on behalf of @lvh