### PR TITLE
org.clojure/clojure 1.8.0-RC1 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/lvh/icecap"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0-beta2"]
+  :dependencies [[org.clojure/clojure "1.8.0-RC1"]
 
                  ;; Stores
                  [com.novemberain/welle "3.0.0"]


### PR DESCRIPTION
org.clojure/clojure 1.8.0-RC1 has been released. Previous version was 1.8.0-beta2.

This pull request is created on behalf of @lvh