### PR TITLE
org.clojure/core.async 0.2.374 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
                   :exclusions [org.clojure/clojure com.taoensso/encore]]
 
                  ;; Handlers
-                 [org.clojure/core.async "0.2.371"]
+                 [org.clojure/core.async "0.2.374"]
                  [aleph "0.4.1-beta2"]
 
                  ;; Schemata


### PR DESCRIPTION
org.clojure/core.async 0.2.374 has been released. Previous version was 0.2.371.

This pull request is created on behalf of @lvh