### PR TITLE
org.clojure/test.check 0.9.0 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -41,7 +41,7 @@
   :main ^:skip-aot icecap.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}
-             :dev {:dependencies [[org.clojure/test.check "0.8.2"]]
+             :dev {:dependencies [[org.clojure/test.check "0.9.0"]]
 
                    :aliases ^:replace {"lint"
                                        ["do"


### PR DESCRIPTION
org.clojure/test.check 0.9.0 has been released. Previous version was 0.8.2.

This pull request is created on behalf of @lvh