### PR TITLE
jonase/eastwood 0.2.2 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -52,7 +52,7 @@
                                         ["kibit"]
                                         ["bikeshed"]
                                         ["eastwood"]]}
-                   :plugins [[jonase/eastwood "0.1.4"]
+                   :plugins [[jonase/eastwood "0.2.2"]
                              [lein-ancient "0.6.8"
                               :exclusions [rewrite-clj]]
                              [lein-bikeshed "0.1.8"]


### PR DESCRIPTION
jonase/eastwood 0.2.2 has been released. Previous version was 0.2.1.

This pull request is created on behalf of @lvh