### PR TITLE
aleph 0.4.1-beta3 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
 
                  ;; Handlers
                  [org.clojure/core.async "0.2.374"]
-                 [aleph "0.4.1-beta2"]
+                 [aleph "0.4.1-beta3"]
 
                  ;; Schemata
                  [prismatic/schema "1.0.3"]


### PR DESCRIPTION
aleph 0.4.1-beta3 has been released. Previous version was 0.4.1-beta2.

This pull request is created on behalf of @lvh