### PR TITLE
prismatic/schema 1.0.4 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,7 @@
                  [aleph "0.4.1-beta3"]
 
                  ;; Schemata
-                 [prismatic/schema "1.0.3"]
+                 [prismatic/schema "1.0.4"]
                  [schema-contrib "0.1.5"
                   :exclusions [instaparse]]
                  [org.clojure/core.typed "0.3.19"]


### PR DESCRIPTION
prismatic/schema 1.0.4 has been released. Previous version was 1.0.3.

This pull request is created on behalf of @lvh